### PR TITLE
Fix uninitialized history list

### DIFF
--- a/src/analysis_page.vala
+++ b/src/analysis_page.vala
@@ -93,7 +93,7 @@ namespace Raccoon{
             var settings_pref = new Settings("Raccoon.jh.xz");
 
             var virtual_root = GLib.File.new_for_uri("virtual://root");
-            List<GLib.File> history = null;
+            List<GLib.File> history = new List<GLib.File>();
             history.append(virtual_root);
             unowned List<GLib.File>? current = history.last();
 


### PR DESCRIPTION
## Summary
- initialize history list in `AnalysisPage`

## Testing
- `meson setup build`
- `ninja -C build` *(fails: UI resource not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5b0ce4883279b7697479084c6a3