### PR TITLE
Add path settings check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ add_project_arguments('-DGETTEXT_PACKAGE="' + meson.project_name () + '"', langu
 
 subdir('data')
 subdir('src')
+subdir('tests')
 subdir('po')
 
 gnome.post_install(

--- a/src/main_page.vala
+++ b/src/main_page.vala
@@ -56,21 +56,16 @@ public class MainPage : Adw.NavigationPage {
         settings_pref = new GLib.Settings("Raccoon.jh.xz");
 
         uris = settings_pref.get_strv("uris");
-      
-        if(uris.length == 0 ){
-            analysis_button.set_sensitive(false);
-            hint_box.set_visible(true);
-        } else {
-            hint_box.set_visible(false);
-        }
+
+        analysis_button.set_sensitive(Raccoon.has_paths(settings_pref));
+        hint_box.set_visible(!Raccoon.has_paths(settings_pref));
         
 
-        settings_pref.changed["uris"].connect (() => {
-            string[] uriss = settings_pref.get_strv("uris");
-            bool has_uris = uriss.length != 0;
-
-            hint_box.set_visible(!has_uris);
-            analysis_button.set_sensitive(has_uris);
+        settings_pref.changed["uris"].connect(() => {
+            uris = settings_pref.get_strv("uris");
+            bool available = Raccoon.has_paths(settings_pref);
+            hint_box.set_visible(!available);
+            analysis_button.set_sensitive(available);
         });
 
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,8 +5,9 @@ racoon_sources = [
 	'history_dialog.vala',
 	'preferences_dialog.vala',
 	'history_row.vala',
-	'path_row.vala',
-	'analysis_page.vala',
+        'path_row.vala',
+        'settings_utils.vala',
+        'analysis_page.vala',
 	'main_page.vala',
     ]
 

--- a/src/settings_utils.vala
+++ b/src/settings_utils.vala
@@ -1,0 +1,11 @@
+namespace Raccoon {
+
+/**
+ * Utility functions related to application settings.
+ */
+public static bool has_paths(GLib.Settings settings) {
+    return settings.get_strv("uris").length != 0;
+}
+
+}
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,15 @@
+test_deps = [
+    dependency('gio-2.0'),
+    dependency('glib-2.0')
+]
+
+settings_utils_test = executable('test_settings_utils',
+    ['test_settings_utils.vala', '../src/settings_utils.vala'],
+    dependencies: test_deps,
+    vala_args: ['--enable-experimental'],
+    include_directories: config_inc
+)
+
+test('settings_utils', settings_utils_test,
+    args: [meson.project_source_root() / 'data']
+)

--- a/tests/test_settings_utils.vala
+++ b/tests/test_settings_utils.vala
@@ -1,0 +1,45 @@
+using GLib;
+using Raccoon;
+
+int main (string[] args) {
+    Test.init (ref args);
+
+    string data_dir = args.length > 1 ? args[1] : "../data";
+    string schema_dir = Path.build_filename (Environment.get_tmp_dir (), "raccoon_test_schema");
+    DirUtils.create (schema_dir, 0755);
+
+    string[] cmd = {"glib-compile-schemas", "--targetdir", schema_dir, data_dir};
+    int status = 0;
+    string? out_str;
+    string? err_str;
+    try {
+        Process.spawn_sync (null, cmd, null, SpawnFlags.SEARCH_PATH, null,
+            out out_str, out err_str, out status);
+    } catch (Error e) {
+        stderr.printf ("Schema compile error: %s\n", e.message);
+        return 1;
+    }
+    if (status != 0) {
+        stderr.printf ("Schema compile failed\n");
+        return 1;
+    }
+
+    Environment.set_variable ("GSETTINGS_SCHEMA_DIR", schema_dir, true);
+
+    Test.add_func ("/settings_utils/has_paths/empty", () => {
+        var settings = new Settings ("Raccoon.jh.xz");
+        settings.set_strv ("uris", {});
+        assert (!Raccoon.has_paths (settings));
+    });
+
+    Test.add_func ("/settings_utils/has_paths/nonempty", () => {
+        var settings = new Settings ("Raccoon.jh.xz");
+        settings.set_strv ("uris", {"file:///tmp"});
+        assert (Raccoon.has_paths (settings));
+    });
+
+    var result = Test.run ();
+    DirUtils.remove (schema_dir);
+    return result;
+}
+


### PR DESCRIPTION
## Summary
- add settings utility for checking path list
- disable analysis button when there are no paths using `has_paths`
- wire up meson to include simple unit tests

## Testing
- `meson setup build`
- `ninja -C build` *(fails: UI resources missing)*
- `meson test -C build` *(fails to build test executable)*

------
https://chatgpt.com/codex/tasks/task_e_683fa6ef10e483279cf73abb3933c084