### PR TITLE
Add dropdown availability check

### DIFF
--- a/src/preferences_dialog.vala
+++ b/src/preferences_dialog.vala
@@ -8,6 +8,9 @@ public class PreferencesDialog : Adw.PreferencesDialog {
     private unowned Gtk.Image sheldule_clean;
 
     [GtkChild]
+    private unowned Adw.ComboRow drop_down;
+
+    [GtkChild]
     private unowned Gtk.Button add_path_button;
     private GLib.Settings settings_pref;
 
@@ -35,6 +38,14 @@ var theme =  Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
     }
 
         settings_pref = new GLib.Settings("Raccoon.jh.xz");
+
+        bool has_uris = settings_pref.get_strv("uris").length != 0;
+        drop_down.set_sensitive(has_uris);
+
+        settings_pref.changed["uris"].connect(() => {
+            bool has = settings_pref.get_strv("uris").length != 0;
+            drop_down.set_sensitive(has);
+        });
 
         foreach (var uri in settings_pref.get_strv ("uris")) {
                 var file = File.new_for_uri (uri);


### PR DESCRIPTION
## Summary
- disable schedule dropdown when no directories are configured
- keep dropdown state updated with GSettings

## Testing
- `meson setup build`
- `PATH=/usr/bin:$PATH meson compile -C build` *(fails: UI resource not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd2b0004c8327af70ca518453760e