### PR TITLE
Adjust history dialog buttons

### DIFF
--- a/data/ui/history_dialog.blp
+++ b/data/ui/history_dialog.blp
@@ -16,6 +16,9 @@ template $RaccoonHistoryDialog : Adw.Dialog {
           label: _("Clear");
           icon-name: "user-trash-symbolic";
         }
+        styles [
+          "destructive-action",
+        ]
       }
 
       title-widget: Adw.WindowTitle {
@@ -26,11 +29,13 @@ template $RaccoonHistoryDialog : Adw.Dialog {
       [end]
       Button {
         icon-name: "selection-mode-symbolic";
+        visible: false;
       }
 
       [end]
       Button {
         icon-name: "edit-find-symbolic";
+        visible: false;
       }
     }
 


### PR DESCRIPTION
## Summary
- apply `destructive-action` style to the history clear button
- hide the selection and search buttons in the history dialog

## Testing
- `meson setup build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd4d371fc8327a1387886e3ff1eb5