### PR TITLE
Adjust history dialog width

### DIFF
--- a/data/ui/history_dialog.blp
+++ b/data/ui/history_dialog.blp
@@ -34,28 +34,19 @@ template $RaccoonHistoryDialog : Adw.Dialog {
       }
     }
 
-    Gtk.ScrolledWindow {
-//xz if it working
-//     propagate-natural-height: true;
+  Gtk.ScrolledWindow {
+    propagate-natural-height: true;
+    max-content-height: 800;
+    min-content-height: 400;
+    margin-start : 10;
+    margin-end: 10;
+    margin-top: 10;
 
-      max-content-height: 800;
-      min-content-height: 400;
-      min-content-width: 200;
-
-
-      Adw.Clamp {
-
-      maximum-size: 600;
-      tightening-threshold: 200;
-     // margin-bottom: 24;
-        Gtk.ListBox listbox_history {
-          selection-mode: single;
-         // Gtk.ListBoxRow{
-              //why error Gtk-CRITICAL **: 13:45:42.423: Error building template class 'RaccoonHistoryDialog' for an instance of type 'RaccoonHistoryDialog': .:0:0 Invalid object type 'RaccoonHistoryRow'
-            //$RaccoonHistoryRow d {}
-         // }
-        }
+    Adw.Clamp {
+      Gtk.ListBox listbox_history {
+        selection-mode: single;
       }
     }
+  }
   }
 }


### PR DESCRIPTION
## Summary
- tweak history dialog layout so its width behaves like the preferences dialog

## Testing
- `meson setup build` *(fails: `meson: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fde8397108327baf9f46eebaffdc0