### PR TITLE
Refactor AnalysisPage and add Utils

### DIFF
--- a/src/analysis_page.vala
+++ b/src/analysis_page.vala
@@ -188,7 +188,7 @@ namespace Raccoon{
                 foreach (var uri in settings_pref.get_strv("uris")) {
                     var file = GLib.File.new_for_uri(uri);
                     if (file.query_exists()) {
-                        total_cleaned += get_recursive_size(file);
+                        total_cleaned += Utils.get_recursive_size(file);
                         delete_files_recursive(uri);
                     }
                 }
@@ -214,7 +214,7 @@ namespace Raccoon{
                 settings_pref.set_string("last-cleanup", now.format("%Y-%m-%d %H:%M:%S"));
 
                 string timestamp = now.format("%Y.%m.%d %H:%M");
-                string size_label = format_file_size((double) total_cleaned, FORM_XIB);
+                string size_label = Utils.format_file_size((double) total_cleaned, FORM_XIB);
                 foreach (var uri in settings_pref.get_strv("uris")) {
                     var file = GLib.File.new_for_uri(uri);
                     if (file.query_exists()) {
@@ -347,10 +347,10 @@ namespace Raccoon{
                 foreach (var uri in uris) {
                     var file = GLib.File.new_for_uri(uri);
                     if (file.query_exists()) {
-                        total_bytes += get_recursive_size(file);
+                        total_bytes += Utils.get_recursive_size(file);
                     }
                 }
-                total_size.set_title(format_file_size(total_bytes, form.FORM_XB));
+                total_size.set_title(Utils.format_file_size(total_bytes, form.FORM_XB));
                 total_size.set_subtitle("🗑 Will be deleted");
             }
 
@@ -367,7 +367,7 @@ namespace Raccoon{
                     var file = model.get_item(i) as GLib.File;
                     if (file == null) continue;
 
-                    int64 file_size = get_recursive_size(file);
+                    int64 file_size = Utils.get_recursive_size(file);
                     total_bytes += file_size;
 
                     if (multi.get_selection().contains(i)) {
@@ -377,46 +377,18 @@ namespace Raccoon{
 
                 int64 will_delete = total_bytes - excluded_bytes;
 
-                total_size.set_title(format_file_size(will_delete, form.FORM_XB));
+                total_size.set_title(Utils.format_file_size(will_delete, form.FORM_XB));
                 total_size.set_subtitle("🗑 Will be deleted");
             }
 
 
-        public int64 get_recursive_size(GLib.File file) {
-            int64 size = 0;
-
-            try {
-                var info = file.query_info("standard::type,standard::size", FileQueryInfoFlags.NONE);
-                switch (info.get_file_type()) {
-                    case FileType.REGULAR:
-                        return info.get_size();
-
-                    case FileType.DIRECTORY:
-                        var enumerator = file.enumerate_children("standard::name", FileQueryInfoFlags.NONE);
-                        FileInfo? file_info;
-
-                        while ((file_info = enumerator.next_file()) != null) {
-                            var child = file.get_child(file_info.get_name());
-                            size += get_recursive_size(child);
-                        }
-                        break;
-
-                    default:
-                        break;
-                }
-            } catch (Error e) {
-                warning("Size error for file %s: %s", file.get_uri(), e.message);
-            }
-
-            return size;
-        }
 
 
 
 
         void show_summary_dialog(Gtk.Window parent, int64 bytes_cleaned) {
             var dialog = new Adw.MessageDialog(parent, "🧹 Cleaning Complete", null);
-            dialog.set_body("You have cleaned " + format_file_size(bytes_cleaned, form.FORM_XB) + ".");
+            dialog.set_body("You have cleaned " + Utils.format_file_size(bytes_cleaned, form.FORM_XB) + ".");
             dialog.add_response("ok", "_OK");
             dialog.set_default_response("ok");
             dialog.set_close_response("ok");
@@ -497,27 +469,6 @@ namespace Raccoon{
             list_view.set_factory(item_factory);
         }
 
-        // uint64 to double
-        // check bug with not correct convert size
-        string format_file_size (double bsize, form f) {
-            string[] units = { "B", "KB", "MB", "GB", "PB" };
-            int i = 0;
-            int formats = 1000;
-
-            if (f == FORM_XIB) {
-                formats = 1024;
-                units[1] = "KiB";
-                units[2] = "MiB";
-                units[3] = "GiB";
-                units[4] = "PiB";
-            }
-
-            while (bsize >= formats && i < units.length - 1) {
-                bsize /= formats;
-                i += 1;
-            }
-            return ("%.2f".printf (bsize) + " " + units[i]);
-        }
 
         public inline uint number_of_folder_children (File f) {
 
@@ -656,7 +607,7 @@ namespace Raccoon{
                     var n_items = number_of_folder_children(file);
                     label.label = (n_items != 0 ? n_items.to_string() + " items" : "Empty");
                 } else {
-                    label.label = format_file_size(size, FORM_XB);
+                    label.label = Utils.format_file_size(size, FORM_XB);
                 }
 
                 // Store file in row to access later

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,8 +6,9 @@ racoon_sources = [
 	'preferences_dialog.vala',
 	'history_row.vala',
 	'path_row.vala',
-	'analysis_page.vala',
-	'main_page.vala',
+        'analysis_page.vala',
+        'utils.vala',
+        'main_page.vala',
     ]
 
 racoon_deps = [

--- a/src/utils.vala
+++ b/src/utils.vala
@@ -1,0 +1,47 @@
+namespace Raccoon {
+    public class Utils {
+        public static string format_file_size(double bsize, form f) {
+            string[] units = { "B", "KB", "MB", "GB", "PB" };
+            int i = 0;
+            int formats = 1000;
+
+            if (f == form.FORM_XIB) {
+                formats = 1024;
+                units[1] = "KiB";
+                units[2] = "MiB";
+                units[3] = "GiB";
+                units[4] = "PiB";
+            }
+
+            while (bsize >= formats && i < units.length - 1) {
+                bsize /= formats;
+                i += 1;
+            }
+            return ("%.2f".printf(bsize) + " " + units[i]);
+        }
+
+        public static int64 get_recursive_size(GLib.File file) {
+            int64 size = 0;
+            try {
+                var info = file.query_info("standard::type,standard::size", FileQueryInfoFlags.NONE);
+                switch (info.get_file_type()) {
+                    case FileType.REGULAR:
+                        return info.get_size();
+                    case FileType.DIRECTORY:
+                        var enumerator = file.enumerate_children("standard::name", FileQueryInfoFlags.NONE);
+                        FileInfo? file_info;
+                        while ((file_info = enumerator.next_file()) != null) {
+                            var child = file.get_child(file_info.get_name());
+                            size += get_recursive_size(child);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            } catch (Error e) {
+                warning("Size error for file %s: %s", file.get_uri(), e.message);
+            }
+            return size;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- split out byte size helpers into `Utils` class
- use the new helpers inside `AnalysisPage`
- update Meson to build the new file

## Testing
- `meson setup build` *(fails: command not found)*
- `valac --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdf62de1c83278d5bb3976fcbecf8