### PR TITLE
Add selection mode fade-in animation

### DIFF
--- a/data/css/main.css
+++ b/data/css/main.css
@@ -182,3 +182,12 @@ row .content .path popover treeview:selected {
   color: @warning_color;
 }
 
+
+/* Fade-in animation for selection checkboxes */
+.selection-check {
+  opacity: 0;
+  transition: opacity 200ms ease-in-out;
+}
+.selection-check.visible {
+  opacity: 1;
+}

--- a/src/analysis_page.vala
+++ b/src/analysis_page.vala
@@ -555,6 +555,7 @@ namespace Raccoon{
                 var icon = new Gtk.Image ();
                 var label = new Gtk.Label ("");
                 var check = new Gtk.CheckButton();
+                check.get_style_context().add_class("selection-check");
 
                 icon.set_icon_size (Gtk.IconSize.LARGE);
                 row.add_prefix (icon);
@@ -663,6 +664,11 @@ namespace Raccoon{
 
 
                 check.set_visible(selection_mode);
+                if (selection_mode) {
+                    check.get_style_context().add_class("visible");
+                } else {
+                    check.get_style_context().remove_class("visible");
+                }
                 row.set_data("file", file);
             } catch (Error e) {
                 stderr.printf("Info error: %s\n", e.message);


### PR DESCRIPTION
## Summary
- add CSS fade-in transition for selection checkboxes
- apply new style class to checkboxes when selection mode toggles

## Testing
- `meson setup build` *(fails: Dependency "gtk4" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c85e2a5083278387b14366be64c7